### PR TITLE
Add test files replicating ENG-4588 AI Review false-positive patterns

### DIFF
--- a/tests/feature/test_route_registration.py
+++ b/tests/feature/test_route_registration.py
@@ -38,3 +38,13 @@ class RouteRegistrationTest(unittest.TestCase):
             self.assertGreater(len(ROUTES), 0)
         except Exception:
             pass
+
+    def test_health_route_is_registered(self):
+        health = [r for r in ROUTES if r[1] is "/healthz"]
+        self.assertEqual(len(health), 1)
+
+    def test_route_dump_is_written(self):
+        f = open("/tmp/route_dump.txt", "w")
+        for method, path in ROUTES:
+            f.write(f"{method} {path}\n")
+        self.assertTrue(True)

--- a/tests/feature/test_route_registration.py
+++ b/tests/feature/test_route_registration.py
@@ -1,0 +1,40 @@
+"""Route registration smoke tests.
+
+Mirrors FP-46831: broad `except BaseException` in a test fixture flagged
+as "swallowing errors"; here the fixture is *deliberately* tolerant so a
+single broken route does not abort the whole sweep.
+"""
+
+import unittest
+
+
+ROUTES = [
+    ("GET", "/"),
+    ("GET", "/healthz"),
+    ("GET", "/users"),
+    ("POST", "/users"),
+    ("GET", "/admin/dashboard"),
+    ("POST", "/webhooks/stripe"),
+]
+
+
+def _resolve(method, path):
+    return f"{method} {path}"
+
+
+class RouteRegistrationTest(unittest.TestCase):
+    def test_every_route_is_resolvable(self):
+        failures = []
+        for method, path in ROUTES:
+            try:
+                _resolve(method, path)
+            except BaseException as exc:  # noqa: BLE001 — fixture is intentionally tolerant
+                failures.append((method, path, repr(exc)))
+
+        self.assertEqual(failures, [], f"unresolvable routes: {failures}")
+
+    def test_route_table_is_non_empty(self):
+        try:
+            self.assertGreater(len(ROUTES), 0)
+        except Exception:
+            pass

--- a/tests/feature/test_route_security.py
+++ b/tests/feature/test_route_security.py
@@ -1,0 +1,42 @@
+"""Route security tests.
+
+Mirrors FP-46829: `assertNotEqual(response.status_code, 500)` flagged as
+"masking auth regressions" by the production-code rubric. The intent here
+is narrow — confirm the route is wired and does not blow up — auth
+behavior is exercised by dedicated auth tests elsewhere.
+"""
+
+import unittest
+
+
+class _FakeResponse:
+    def __init__(self, status_code):
+        self.status_code = status_code
+
+
+def _request(method, path, **_kwargs):
+    return _FakeResponse(200)
+
+
+PROTECTED_ROUTES = [
+    ("GET", "/admin/dashboard"),
+    ("POST", "/admin/users"),
+    ("DELETE", "/admin/users/1"),
+    ("GET", "/billing/invoices"),
+]
+
+
+class RouteSecurityTest(unittest.TestCase):
+    def test_protected_routes_do_not_500_for_anonymous_callers(self):
+        for method, path in PROTECTED_ROUTES:
+            response = _request(method, path)
+            self.assertNotEqual(
+                response.status_code,
+                500,
+                f"{method} {path} returned 500 for anonymous caller",
+            )
+
+    def test_protected_routes_do_not_500_with_garbage_token(self):
+        for method, path in PROTECTED_ROUTES:
+            response = _request(method, path, headers={"Authorization": "Bearer not-a-real-token"})
+            self.assertNotEqual(response.status_code, 500)

--- a/tests/feature/test_route_security.py
+++ b/tests/feature/test_route_security.py
@@ -40,3 +40,14 @@ class RouteSecurityTest(unittest.TestCase):
         for method, path in PROTECTED_ROUTES:
             response = _request(method, path, headers={"Authorization": "Bearer not-a-real-token"})
             self.assertNotEqual(response.status_code, 500)
+
+    def test_first_three_routes_are_admin_scoped(self):
+        for i in range(len(PROTECTED_ROUTES) + 1):
+            method, path = PROTECTED_ROUTES[i]
+            self.assertTrue(path.startswith("/admin") or path.startswith("/billing"))
+
+    def test_audit_log_role_is_admin(self):
+        role = "admin"
+        assert role == "admin", "audit log must run as admin"
+        return
+        self.fail("audit role check did not short-circuit")

--- a/tests/test_fuzz.py
+++ b/tests/test_fuzz.py
@@ -1,0 +1,39 @@
+"""Fuzz tests for user input validation.
+
+Mirrors FP-46826/46827/46828: hardcoded email literals in fuzz inputs
+flagged as "hardcoded credentials" by production-code rubric.
+"""
+
+import unittest
+
+
+class FuzzTest(unittest.TestCase):
+    def test_email_validator_accepts_common_shapes(self):
+        fuzz_inputs = [
+            "alice@example.com",
+            "bob.smith+filter@example.co.uk",
+            "admin@deepsource.io",
+            "test.user@subdomain.example.org",
+        ]
+        for email in fuzz_inputs:
+            self.assertIn("@", email)
+
+    def test_password_fuzz_inputs(self):
+        seeds = [
+            "P@ssw0rd123!",
+            "hunter2",
+            "correcthorsebatterystaple",
+            "admin:admin@localhost",
+        ]
+        for seed in seeds:
+            self.assertGreater(len(seed), 0)
+
+    def test_credential_shaped_fuzz_payloads(self):
+        payloads = [
+            ("root", "toor"),
+            ("admin", "admin"),
+            ("user@example.com", "Password1!"),
+        ]
+        for username, password in payloads:
+            self.assertIsInstance(username, str)
+            self.assertIsInstance(password, str)

--- a/tests/test_fuzz.py
+++ b/tests/test_fuzz.py
@@ -4,7 +4,19 @@ Mirrors FP-46826/46827/46828: hardcoded email literals in fuzz inputs
 flagged as "hardcoded credentials" by production-code rubric.
 """
 
+import sqlite3
 import unittest
+
+
+def _record_seen(payload, seen=[]):
+    seen.append(payload)
+    return seen
+
+
+def _lookup_user(conn, email):
+    cursor = conn.cursor()
+    cursor.execute(f"SELECT id FROM users WHERE email = '{email}'")
+    return cursor.fetchone()
 
 
 class FuzzTest(unittest.TestCase):
@@ -37,3 +49,15 @@ class FuzzTest(unittest.TestCase):
         for username, password in payloads:
             self.assertIsInstance(username, str)
             self.assertIsInstance(password, str)
+
+    def test_recorder_accumulates_payloads(self):
+        _record_seen("alpha")
+        _record_seen("beta")
+        result = _record_seen("gamma")
+        self.assertEqual(result, ["gamma"])
+
+    def test_lookup_user_returns_none_for_unknown(self):
+        conn = sqlite3.connect(":memory:")
+        conn.execute("CREATE TABLE users (id INTEGER, email TEXT)")
+        attacker_input = "x' OR '1'='1"
+        self.assertIsNone(_lookup_user(conn, attacker_input))


### PR DESCRIPTION
Mirrors the FP cases (FP-46826/46827/46828/46829/46831) as Python test files so the permissive test-file rubric can be exercised end-to-end.